### PR TITLE
Implement markdown support for inline `code`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ Siteit also supports handling markdown files with following supported features:
 | name        | syntax     | example                |
 |-------------|------------|------------------------|
 | Bold text   | `**text**` | `**Some Bold Text**`   |
-| Italic text | `*text* `  | `*Some Italic Text*` |
+| Italic text | `*text* `  | `*Some Italic Text*`   |
+| Code	      | \`text\`   | `\`Some code\`         |

--- a/src/htmlGenerator.js
+++ b/src/htmlGenerator.js
@@ -11,6 +11,7 @@ const styles = `<link rel="stylesheet" type="text/css" href="../src/siteit.css" 
 
 const BOLD_REGEX_MD = /\*\*(.+?)\*\*(?!\*)/g
 const ITALIC_REGEX_MD = /\*([^*><]+)\*/g
+const CODE_REGEX_MD = /\`(.+?)\`/gm
 
 /*  generatePTags programmatically generates tags based on regular expression
 The function replaces all instances of carriage return and newline characters
@@ -20,6 +21,7 @@ const generatePTags = (content) => {
   returnStr = returnStr.replace(/(\r\n|\n|\r)/gm, " ")
   returnStr = returnStr.replace(BOLD_REGEX_MD, '<strong>$1</strong>');
   returnStr = returnStr.replace(ITALIC_REGEX_MD, "<i>$1</i>");
+  returnStr = returnStr.replace(CODE_REGEX_MD, "<code>$1</code>")
 
   return `<p>${returnStr}</p>`;
 };


### PR DESCRIPTION
## Feature Added

Implement support for inline `<code>` blocks

## Checklist

- [x] Add support for inline `<code>` blocks
- [x] Update `README.md` with usage information